### PR TITLE
Fix misleading `elfeed-score-serde-score-mark` docstring

### DIFF
--- a/elfeed-score-serde.el
+++ b/elfeed-score-serde.el
@@ -68,7 +68,7 @@ deserialization of scoring rules."
   "List of structs each defining a scoring rule based on a user-defined function.")
 
 (defvar elfeed-score-serde-score-mark nil
-  "Score at or below which entries shall be marked as read.")
+  "Score below which entries shall be marked as read.")
 
 (defvar elfeed-score-serde-adjust-tags-rules nil
   "List of rules to be run after scoring to adjust tags based on score.")


### PR DESCRIPTION
`<=` -> `<`

https://github.com/sp1ff/elfeed-score/blob/419de17d681d75789271b8457509fa3f942eab54/elfeed-score-scoring.el#L659-L661

https://github.com/sp1ff/elfeed-score/blob/419de17d681d75789271b8457509fa3f942eab54/doc/elfeed-score.texi#L991-L994