### PR TITLE
Use with-help-window to make the explanation buffer easily quittable

### DIFF
--- a/elfeed-score-scoring.el
+++ b/elfeed-score-scoring.el
@@ -707,8 +707,8 @@ This function is used in `elfeed-new-entry-hook'."
     (t
      (error "Don't know how to evaluate %S" match))))
 
-(defun elfeed-score-scoring-explain-entry (entry)
-  "Explain an Elfeed ENTRY.
+(defun elfeed-score-scoring-explain-entry (entry buffer)
+  "Explain an Elfeed ENTRY in BUFFER.
 
 This function will apply all scoring rules to an entry, but will
 not change anything (e.g.  update ENTRY's meta-data, or the
@@ -736,9 +736,7 @@ understanding of scoring rules."
            :initial-value elfeed-score-scoring-default-score))
          (sticky (and elfeed-score-scoring-manual-is-sticky
                       (elfeed-score-scoring-entry-is-sticky entry))))
-    (with-current-buffer-window
-        elfeed-score-scoring-explanation-buffer-name
-        nil nil
+    (with-current-buffer buffer
       (goto-char (point-max))
       (insert
        (if sticky
@@ -777,20 +775,20 @@ to the rules currently in-memory)\n")
                   (format "    %d. %s\n" (1+ idx)
                           (elfeed-score-scoring--pp-rule-match-to-string match)))))
             (cl-loop
-                 for match being the elements of matches using (index idx)
-                 do
-                 (insert
-                  (format "    %d. " (1+ idx)))
-                 (insert-text-button
-                  (elfeed-score-scoring--pp-rule-match-to-string match)
-                  'tag (elfeed-score-serde-tag-for-explanation match)
-                  'index (elfeed-score-rules-index-for-explanation match)
-                  'action
-                  (lambda (btn)
-                    (elfeed-score-scoring-visit-rule
-                     (button-get btn 'tag)
-                     (button-get btn 'index))))
-                 (insert "\n"))))))))
+             for match being the elements of matches using (index idx)
+             do
+             (insert
+              (format "    %d. " (1+ idx)))
+             (insert-text-button
+              (elfeed-score-scoring--pp-rule-match-to-string match)
+              'tag (elfeed-score-serde-tag-for-explanation match)
+              'index (elfeed-score-rules-index-for-explanation match)
+              'action
+              (lambda (btn)
+                (elfeed-score-scoring-visit-rule
+                 (button-get btn 'tag)
+                 (button-get btn 'index))))
+             (insert "\n"))))))))
 
 (defun elfeed-score-scoring-visit-rule (tag index)
   "Visit rule TAG, INDEX in the score file.

--- a/elfeed-score.el
+++ b/elfeed-score.el
@@ -143,8 +143,10 @@ point will be explained.  If the region is not active, only the
 entry under point will be explained."
   (interactive)
   (let ((entries (elfeed-search-selected ignore-region)))
-    (dolist (entry entries)
-      (elfeed-score-scoring-explain-entry entry))
+    (with-help-window elfeed-score-scoring-explanation-buffer-name
+      (with-current-buffer elfeed-score-scoring-explanation-buffer-name
+        (dolist (entry entries)
+          (elfeed-score-scoring-explain-entry entry (current-buffer)))))
     (elfeed-search-update t)))
 
 (defun elfeed-score-load-score-file (score-file)

--- a/test/test-explanations.el
+++ b/test/test-explanations.el
@@ -62,7 +62,7 @@
               (list (elfeed-score-tag-rule--create :tags '(b c d) :value 1)))
              (elfeed-score-serde-udf-rules
               (list (elfeed-score-udf-rule--create :function (lambda (_) 1)))))
-        (elfeed-score-scoring-explain-entry entry)
+        (elfeed-score-scoring-explain-entry entry elfeed-score-scoring-explanation-buffer-name)
         (let ((text
                (with-current-buffer "*explanation-smoke-tests*"
                  (buffer-string))))


### PR DESCRIPTION
Currently, the score explanation is shown in a fundamental-mode buffer.  Putting it a help-mode buffer means that a binding to close the window is readily available.